### PR TITLE
Checkboxコンポーネントを実装

### DIFF
--- a/src/pages/Playground.vue
+++ b/src/pages/Playground.vue
@@ -180,7 +180,7 @@
             <p :class="$style.componentPath">CheckboxField.vue</p>
             <h2 :class="$style.sectionTitle">Checkbox</h2>
           </div>
-          <span :class="$style.sectionNote">checked / disabled</span>
+          <span :class="$style.sectionNote">checked / disabled / no slot</span>
         </div>
         <div :class="$style.preview">
           <div :class="$style.inlineItems">
@@ -191,6 +191,13 @@
               チェック済み始まり
             </CheckboxField>
             <CheckboxField model-value disabled>disabled</CheckboxField>
+          </div>
+          <div :class="$style.inlineItems">
+            <span :class="$style.previewLabel">slotなし(aria-labelのみ)</span>
+            <CheckboxField
+              v-model="checkboxNoSlot"
+              v-bind="{ ariaLabel: '全件選択' }"
+            />
           </div>
         </div>
       </section>
@@ -315,6 +322,7 @@ const radioOptions = [
 const selectedRadio = ref<string | undefined>('standard');
 const checkboxUnchecked = ref(false);
 const checkboxChecked = ref(true);
+const checkboxNoSlot = ref(false);
 const textInputValue = ref('');
 const lastEvent = ref(
   'コンポーネントを操作すると、ここにイベントが表示されます',
@@ -347,6 +355,12 @@ watch(checkboxUnchecked, (value) => {
 watch(checkboxChecked, (value) => {
   recordEvent(
     `CheckboxField / チェック済み始まり を ${value ? 'チェック' : '未チェック'} に`,
+  );
+});
+
+watch(checkboxNoSlot, (value) => {
+  recordEvent(
+    `CheckboxField / slotなし(全件選択) を ${value ? 'チェック' : '未チェック'} に`,
   );
 });
 </script>

--- a/src/pages/Playground.vue
+++ b/src/pages/Playground.vue
@@ -174,6 +174,27 @@
         </div>
       </section>
 
+      <section id="checkbox" :class="$style.section">
+        <div :class="$style.sectionHeading">
+          <div>
+            <p :class="$style.componentPath">CheckboxField.vue</p>
+            <h2 :class="$style.sectionTitle">Checkbox</h2>
+          </div>
+          <span :class="$style.sectionNote">checked / disabled</span>
+        </div>
+        <div :class="$style.preview">
+          <div :class="$style.inlineItems">
+            <CheckboxField v-model="checkboxUnchecked">
+              未チェック始まり
+            </CheckboxField>
+            <CheckboxField v-model="checkboxChecked">
+              チェック済み始まり
+            </CheckboxField>
+            <CheckboxField model-value disabled>disabled</CheckboxField>
+          </div>
+        </div>
+      </section>
+
       <section id="chips" :class="$style.section">
         <div :class="$style.sectionHeading">
           <div>
@@ -249,6 +270,7 @@ import { ref, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 import AppHeader from '@/shared/components/AppHeader.vue';
 import AppLogo from '@/shared/components/AppLogo.vue';
+import CheckboxField from '@/shared/components/CheckboxField.vue';
 import ChipButton from '@/shared/components/ChipButton.vue';
 import ChipCard from '@/shared/components/ChipCard.vue';
 import IconAvatar from '@/shared/components/IconAvatar.vue';
@@ -266,6 +288,7 @@ const sections = [
   { id: 'brand-icons', label: 'Brand & Icons' },
   { id: 'text-input', label: 'Text Input' },
   { id: 'radio-card', label: 'Radio Card' },
+  { id: 'checkbox', label: 'Checkbox' },
   { id: 'chips', label: 'Chips' },
 ];
 
@@ -290,6 +313,8 @@ const radioOptions = [
 ];
 
 const selectedRadio = ref<string | undefined>('standard');
+const checkboxUnchecked = ref(false);
+const checkboxChecked = ref(true);
 const textInputValue = ref('');
 const lastEvent = ref(
   'コンポーネントを操作すると、ここにイベントが表示されます',
@@ -311,6 +336,18 @@ const handleTextInput = (
 
 watch(selectedRadio, (value) => {
   recordEvent(`RadioCard / ${value} を選択`);
+});
+
+watch(checkboxUnchecked, (value) => {
+  recordEvent(
+    `CheckboxField / 未チェック始まり を ${value ? 'チェック' : '未チェック'} に`,
+  );
+});
+
+watch(checkboxChecked, (value) => {
+  recordEvent(
+    `CheckboxField / チェック済み始まり を ${value ? 'チェック' : '未チェック'} に`,
+  );
 });
 </script>
 

--- a/src/pages/Playground.vue
+++ b/src/pages/Playground.vue
@@ -183,21 +183,26 @@
           <span :class="$style.sectionNote">checked / disabled / no slot</span>
         </div>
         <div :class="$style.preview">
-          <div :class="$style.inlineItems">
-            <CheckboxField v-model="checkboxUnchecked">
-              未チェック始まり
-            </CheckboxField>
-            <CheckboxField v-model="checkboxChecked">
-              チェック済み始まり
-            </CheckboxField>
-            <CheckboxField model-value disabled>disabled</CheckboxField>
+          <div :class="$style.previewGroup">
+            <p :class="$style.previewLabel">ラベルあり</p>
+            <div :class="$style.inlineItems">
+              <CheckboxField v-model="checkboxUnchecked">
+                未チェック始まり
+              </CheckboxField>
+              <CheckboxField v-model="checkboxChecked">
+                チェック済み始まり
+              </CheckboxField>
+              <CheckboxField model-value disabled>disabled</CheckboxField>
+            </div>
           </div>
-          <div :class="$style.inlineItems">
-            <span :class="$style.previewLabel">slotなし(aria-labelのみ)</span>
-            <CheckboxField
-              v-model="checkboxNoSlot"
-              v-bind="{ ariaLabel: '全件選択' }"
-            />
+          <div :class="$style.previewGroup">
+            <p :class="$style.previewLabel">slotなし(aria-labelのみ)</p>
+            <div :class="$style.inlineItems">
+              <CheckboxField
+                v-model="checkboxNoSlot"
+                v-bind="{ ariaLabel: 'aria-labelのみ' }"
+              />
+            </div>
           </div>
         </div>
       </section>
@@ -360,7 +365,7 @@ watch(checkboxChecked, (value) => {
 
 watch(checkboxNoSlot, (value) => {
   recordEvent(
-    `CheckboxField / slotなし(全件選択) を ${value ? 'チェック' : '未チェック'} に`,
+    `CheckboxField / aria-labelのみ を ${value ? 'チェック' : '未チェック'} に`,
   );
 });
 </script>

--- a/src/shared/components/CheckboxField.vue
+++ b/src/shared/components/CheckboxField.vue
@@ -22,6 +22,12 @@ const checkboxDesignTokens = {
     borderColor: 'var(--color-secondary)',
     checkedBackground: 'var(--color-primary)',
     checkedBorderColor: 'var(--color-primary)',
+    focusRing: {
+      width: '2px',
+      style: 'solid',
+      color: 'var(--color-primary)',
+      offset: '2px',
+    },
   },
 };
 </script>

--- a/src/shared/components/CheckboxField.vue
+++ b/src/shared/components/CheckboxField.vue
@@ -1,0 +1,60 @@
+<script lang="ts" setup>
+import { Icon } from '@iconify/vue';
+import PrimeCheckbox from 'primevue/checkbox';
+
+defineProps<{
+  disabled?: boolean;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+}>();
+
+const model = defineModel<boolean>({ default: false });
+
+const checkboxDesignTokens = {
+  root: {
+    width: '1.5rem',
+    height: '1.5rem',
+    background: 'var(--color-secondary-container)',
+    borderColor: 'var(--color-secondary)',
+  },
+};
+</script>
+
+<template>
+  <label
+    v-if="$slots['default']"
+    :class="[
+      'flex items-center gap-2 text-base',
+      disabled
+        ? 'cursor-not-allowed text-(--color-text-disabled)'
+        : 'cursor-pointer text-(--color-text)',
+    ]"
+  >
+    <PrimeCheckbox
+      v-model="model"
+      binary
+      :disabled="disabled"
+      :ariaLabel="ariaLabel"
+      :ariaLabelledby="ariaLabelledby"
+      :dt="checkboxDesignTokens"
+    >
+      <template #icon="{ checked }">
+        <Icon v-if="checked" icon="mdi:check" class="h-4 w-4 text-white" />
+      </template>
+    </PrimeCheckbox>
+    <span><slot /></span>
+  </label>
+  <PrimeCheckbox
+    v-else
+    v-model="model"
+    binary
+    :disabled="disabled"
+    :ariaLabel="ariaLabel"
+    :ariaLabelledby="ariaLabelledby"
+    :dt="checkboxDesignTokens"
+  >
+    <template #icon="{ checked }">
+      <Icon v-if="checked" icon="mdi:check" class="h-4 w-4 text-white" />
+    </template>
+  </PrimeCheckbox>
+</template>

--- a/src/shared/components/CheckboxField.vue
+++ b/src/shared/components/CheckboxField.vue
@@ -2,6 +2,10 @@
 import { Icon } from '@iconify/vue';
 import PrimeCheckbox from 'primevue/checkbox';
 
+defineOptions({
+  inheritAttrs: false,
+});
+
 defineProps<{
   disabled?: boolean;
   ariaLabel?: string;
@@ -36,7 +40,7 @@ const checkboxDesignTokens = {
       v-model="model"
       binary
       :disabled="disabled"
-      v-bind="{ ariaLabel, ariaLabelledby }"
+      v-bind="{ ariaLabel, ariaLabelledby, ...$attrs }"
       :dt="checkboxDesignTokens"
     >
       <template #icon="{ checked }">
@@ -54,11 +58,15 @@ const checkboxDesignTokens = {
     v-model="model"
     binary
     :disabled="disabled"
-    v-bind="{ ariaLabel, ariaLabelledby }"
+    v-bind="{ ariaLabel, ariaLabelledby, ...$attrs }"
     :dt="checkboxDesignTokens"
   >
     <template #icon="{ checked }">
-      <Icon v-if="checked" icon="mdi:check" class="h-4 w-4 text-white" />
+      <Icon
+        v-if="checked"
+        icon="mdi:check"
+        class="h-4 w-4 text-(--color-text-on-primary)"
+      />
     </template>
   </PrimeCheckbox>
 </template>

--- a/src/shared/components/CheckboxField.vue
+++ b/src/shared/components/CheckboxField.vue
@@ -34,8 +34,7 @@ const checkboxDesignTokens = {
       v-model="model"
       binary
       :disabled="disabled"
-      :ariaLabel="ariaLabel"
-      :ariaLabelledby="ariaLabelledby"
+      v-bind="{ ariaLabel, ariaLabelledby }"
       :dt="checkboxDesignTokens"
     >
       <template #icon="{ checked }">
@@ -49,8 +48,7 @@ const checkboxDesignTokens = {
     v-model="model"
     binary
     :disabled="disabled"
-    :ariaLabel="ariaLabel"
-    :ariaLabelledby="ariaLabelledby"
+    v-bind="{ ariaLabel, ariaLabelledby }"
     :dt="checkboxDesignTokens"
   >
     <template #icon="{ checked }">

--- a/src/shared/components/CheckboxField.vue
+++ b/src/shared/components/CheckboxField.vue
@@ -16,6 +16,8 @@ const checkboxDesignTokens = {
     height: '1.5rem',
     background: 'var(--color-secondary-container)',
     borderColor: 'var(--color-secondary)',
+    checkedBackground: 'var(--color-primary)',
+    checkedBorderColor: 'var(--color-primary)',
   },
 };
 </script>
@@ -38,7 +40,11 @@ const checkboxDesignTokens = {
       :dt="checkboxDesignTokens"
     >
       <template #icon="{ checked }">
-        <Icon v-if="checked" icon="mdi:check" class="h-4 w-4 text-white" />
+        <Icon
+          v-if="checked"
+          icon="mdi:check"
+          class="h-4 w-4 text-(--color-text-on-primary)"
+        />
       </template>
     </PrimeCheckbox>
     <span><slot /></span>


### PR DESCRIPTION
close #53 
- PrimeVueのCheckboxをラップしました
- 以下の内容を踏まえ、コンポーネント名を `CheckboxField.vue` にしました
  - PrimeVue のコンポーネントとは違い、チェック部分だけでなく、ラベルも含めたコンポーネントとしているため
  - 一単語のファイル名は linter の規則で警告するようにしてあるため

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - チェックボックスコンポーネントを追加しました。
  - 未チェック、チェック済み、無効状態を表示できるようになりました。
  - ラベル付き・ラベルなしの表示に対応しました。
  - チェック状態に応じたアイコン表示を追加しました。
  - アクセシビリティ向けのARIA属性に対応しました。
  - Playgroundで各状態を確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->